### PR TITLE
invalid method name

### DIFF
--- a/lib/react-webcam.js
+++ b/lib/react-webcam.js
@@ -92,7 +92,7 @@ class Webcam extends Component {
 
   componentWillUnmount() {
     if (this.state.hasUserMedia) {
-      window.URL.revokeObjectUrl(this.state.src);
+      window.URL.revokeObjectURL(this.state.src);
     }
   }
 


### PR DESCRIPTION
window.URL.revokeObjectURL did not have correct case, and was throwing