### PR TITLE
Add support to add custom class to video tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ class Component extends React.Component {
   'image/webp'.
 * onUserMedia: function | Callback when component receives a media
   stream.
+* className: 'string' | CSS class of video element. Default is empty.
 
 ## License
 

--- a/src/react-webcam.js
+++ b/src/react-webcam.js
@@ -29,7 +29,8 @@ export default class Webcam extends Component {
       'image/webp',
       'image/png',
       'image/jpeg'
-    ])
+    ]),
+    className: PropTypes.string
   };
 
   static mountedInstances = [];
@@ -182,6 +183,7 @@ export default class Webcam extends Component {
         width={this.props.width}
         height={this.props.height}
         src={this.state.src}
+        className={this.props.className}
       />
     );
   }


### PR DESCRIPTION
In order to enable customize the video tag with some sort of CSS, it adds the props `className`